### PR TITLE
Fix treatment of None

### DIFF
--- a/prettyjson.py
+++ b/prettyjson.py
@@ -35,7 +35,6 @@ def getsubitems(obj, itemkey, islast, maxlinelength, indent):
         if itemkey != "": opening = itemkey + ": " + opening
         if not islast: closing += ","
 
-        count = 0
         itemkey = ""
         subitems = []
 
@@ -65,7 +64,6 @@ def getsubitems(obj, itemkey, islast, maxlinelength, indent):
             if (multiline):
                 lines = []
                 current_line = ""
-                current_index = 0
 
                 for (i, item) in enumerate(subitems):
                     item_text = item
@@ -92,7 +90,7 @@ def getsubitems(obj, itemkey, islast, maxlinelength, indent):
             else: # single-line mode
                 totallength = len(subitems)-1   # spaces between items
                 for item in subitems: totallength += len(item)
-                if (totallength <= maxlinelength): 
+                if (totallength <= maxlinelength):
                     str = ""
                     for item in subitems: str += item + " "  # insert space between items, comma is already there
                     subitems = [ str.strip() ]               # wrap concatenated content in a new list
@@ -100,7 +98,7 @@ def getsubitems(obj, itemkey, islast, maxlinelength, indent):
                     is_inline = False
 
 
-        # attempt to render the outer brackets + inner tokens in one line 
+        # attempt to render the outer brackets + inner tokens in one line
         if is_inline:
             item_text = ""
             if len(subitems) > 0: item_text = subitems[0]
@@ -114,15 +112,17 @@ def getsubitems(obj, itemkey, islast, maxlinelength, indent):
             items.append(opening)       # opening brackets
             items.append(subitems)      # Append children to parent list as a nested list
             items.append(closing)       # closing brackets
-    
+
     return items, is_inline
 
 
 def basictype2str(obj):
     if isinstance (obj, str):
         strobj = "\"" + str(obj) + "\""
-    elif isinstance(obj, bool): 
+    elif isinstance(obj, bool):
         strobj = { True: "true", False: "false" }[obj]
+    elif obj is None:
+        strobj = "null"
     else:
         strobj = str(obj)
     return strobj
@@ -133,7 +133,7 @@ def indentitems(items, indent, level):
     res = ""
     indentstr = " " * (indent * level)
     for (i, item) in enumerate(items):
-        if isinstance(item, list): 
+        if isinstance(item, list):
             res += indentitems(item, indent, level+1)
         else:
             islast = (i==len(items)-1)
@@ -141,6 +141,5 @@ def indentitems(items, indent, level):
             if level==0 and islast:
                 res += indentstr + item
             else:
-                res += indentstr + item + "\n"            
+                res += indentstr + item + "\n"
     return res
-


### PR DESCRIPTION
`prettyjson` currently prints `None` as `"None"` instead of `"null"`, which causes problems when reading the output after saving as JSON. This PR:

- fixes the printing of `None`;
- eliminates two unused variables;
- eliminates some trailing white space.